### PR TITLE
feat: `PartialLiquidationV3` bot upgrade

### DIFF
--- a/contracts/bots/PartialLiquidationBotV3.sol
+++ b/contracts/bots/PartialLiquidationBotV3.sol
@@ -111,12 +111,17 @@ contract PartialLiquidationBotV3 is IPartialLiquidationBotV3, ReentrancyGuardTra
         feeScaleFactor = feeScaleFactor_;
     }
 
+    /// @notice Returns serialized bot's parameters
+    function serialize() external view returns (bytes memory) {
+        return abi.encode(treasury, minHealthFactor, maxHealthFactor, premiumScaleFactor, feeScaleFactor);
+    }
+
     // ----------- //
     // LIQUIDATION //
     // ----------- //
 
     /// @inheritdoc IPartialLiquidationBotV3
-    function liquidateExactDebt(
+    function partiallyLiquidate(
         address creditAccount,
         address token,
         uint256 repaidAmount,
@@ -213,7 +218,9 @@ contract PartialLiquidationBotV3 is IPartialLiquidationBotV3, ReentrancyGuardTra
         ICreditFacadeV3(vars.creditFacade).botMulticall(creditAccount, calls);
         receivedAmount = IERC20(vars.receivedToken).safeBalanceOf(to) - balanceBefore;
 
-        emit LiquidatePartial(vars.creditManager, creditAccount, vars.receivedToken, repaidAmount, receivedAmount, fee);
+        emit PartiallyLiquidate(
+            vars.creditManager, creditAccount, vars.receivedToken, repaidAmount, receivedAmount, fee
+        );
     }
 
     /// @dev Ensures that `creditAccount`'s health factor is within allowed range after partial liquidation

--- a/contracts/interfaces/IPartialLiquidationBotV3.sol
+++ b/contracts/interfaces/IPartialLiquidationBotV3.sol
@@ -21,7 +21,7 @@ interface IPartialLiquidationBotV3 is IBot {
     /// @param repaidDebt Amount of `creditAccount`'s debt repaid
     /// @param seizedCollateral Amount of `token` seized from `creditAccount`
     /// @param fee Amount of underlying sent to the treasury as liqudiation fee
-    event LiquidatePartial(
+    event PartiallyLiquidate(
         address indexed creditManager,
         address indexed creditAccount,
         address indexed token,
@@ -80,7 +80,7 @@ interface IPartialLiquidationBotV3 is IBot {
     /// @dev Reverts if `creditAccount`'s health factor is not within allowed range after liquidation
     /// @dev If `token` is a phantom token, it's withdrawn first, and its `depositedToken` is then sent to the liquidator.
     ///      Both `seizedAmount` and `minSeizedAmount` refer to `depositedToken` in this case.
-    function liquidateExactDebt(
+    function partiallyLiquidate(
         address creditAccount,
         address token,
         uint256 repaidAmount,

--- a/contracts/interfaces/IPartialLiquidationBotV3.sol
+++ b/contracts/interfaces/IPartialLiquidationBotV3.sol
@@ -40,9 +40,6 @@ interface IPartialLiquidationBotV3 is IBot {
     /// @notice Thrown when health factor after liquidation is greater than maximum allowed
     error LiquidatedMoreThanNeededException();
 
-    /// @notice Thrown when amount of underlying repaid is greater than allowed
-    error RepaidMoreThanAllowedException();
-
     /// @notice Thrown when amount of collateral seized is less than required
     error SeizedLessThanRequiredException();
 
@@ -89,26 +86,4 @@ interface IPartialLiquidationBotV3 is IBot {
         address to,
         PriceUpdate[] calldata priceUpdates
     ) external returns (uint256 seizedAmount);
-
-    /// @notice Liquidates credit account by repaying its debt in exchange for the given amount of discounted collateral
-    /// @param creditAccount Credit account to liquidate
-    /// @param token Collateral token to seize
-    /// @param seizedAmount Amount of `token` to seize from `creditAccount`
-    /// @param maxRepaidAmount Maxiumum amount of underlying to repay
-    /// @param to Address to send seized `token` to
-    /// @param priceUpdates On-demand price feed updates to apply before calculations
-    /// @return repaidAmount Amount of underlying repaid
-    /// @dev Requires underlying token approval from caller to this contract
-    /// @dev Reverts if `token` is underlying
-    /// @dev Reverts if `creditAccount`'s health factor is not less than `minHealthFactor` before liquidation
-    /// @dev Reverts if amount of underlying to be repaid is greater than `maxRepaidAmount`
-    /// @dev Reverts if `creditAccount`'s health factor is not within allowed range after liquidation
-    function liquidateExactCollateral(
-        address creditAccount,
-        address token,
-        uint256 seizedAmount,
-        uint256 maxRepaidAmount,
-        address to,
-        PriceUpdate[] calldata priceUpdates
-    ) external returns (uint256 repaidAmount);
 }

--- a/contracts/interfaces/IPartialLiquidationBotV3.sol
+++ b/contracts/interfaces/IPartialLiquidationBotV3.sol
@@ -74,10 +74,12 @@ interface IPartialLiquidationBotV3 is IBot {
     /// @param priceUpdates On-demand price feed updates to apply before calculations
     /// @return seizedAmount Amount of `token` seized
     /// @dev Requires underlying token approval from caller to this contract
-    /// @dev Reverts if `token` is underlying
+    /// @dev Reverts if `token` is underlying or if `token` is a phantom token and its `depositedToken` is underlying
     /// @dev Reverts if `creditAccount`'s health factor is not less than `minHealthFactor` before liquidation
     /// @dev Reverts if amount of `token` to be seized is less than `minSeizedAmount`
     /// @dev Reverts if `creditAccount`'s health factor is not within allowed range after liquidation
+    /// @dev If `token` is a phantom token, it's withdrawn first, and its `depositedToken` is then sent to the liquidator.
+    ///      Both `seizedAmount` and `minSeizedAmount` refer to `depositedToken` in this case.
     function liquidateExactDebt(
         address creditAccount,
         address token,


### PR DESCRIPTION
In this PR:
* remove `liquidateExactCollateral`, rename `liquidateExactDebt` into `partiallyLiquidate`
* support fee-on-transfer underlyings and phantom collaterals
* add serialization